### PR TITLE
Changes DpaHandler2 to own the channel resource.

### DIFF
--- a/Dpa/DpaHandler2.cpp
+++ b/Dpa/DpaHandler2.cpp
@@ -77,6 +77,8 @@ public:
     }
     m_dpaTransactionQueue->stopQueue();
     delete m_dpaTransactionQueue;
+    // Delete owned resource.
+    delete m_iqrfInterface;
   }
 
   // any received message from the channel

--- a/Dpa/DpaHandler2.h
+++ b/Dpa/DpaHandler2.h
@@ -23,6 +23,9 @@
 
 class DpaHandler2 : public IDpaHandler2 {
 public:
+  /**
+   * @param iqrfInterface Is owned by this.
+   */
   DpaHandler2( IChannel* iqrfInterface );
   virtual ~DpaHandler2();
   std::shared_ptr<IDpaTransaction2> executeDpaTransaction( const DpaMessage& request, int32_t timeout,


### PR DESCRIPTION
This change ensures that if users (when cleaning up their usage of 'clibdpa') only delete `DpaHandler2`, that the `IChannel` resource will also be cleaned up. This could for instance happen when they restart a part of their system that uses IQRF and clibdpa.

However, if there are users that also clean up the `IChannel` resource directly, this change might cause bugs and errors for them. This is basically a change of the interface for using `DpaHandler2` AFAICT (namely who owns the given resources and has the responsibility for cleaning them up), so it may make sense to reject the pull request.

It seems to me that it may make sense to make this change, since it partially fits with the `IChannel` resource not being cleaned up directly in [the example](https://github.com/iqrfsdk/clibdpa/blob/master/DpaExamples/Example.cpp), and partially that I could imagine that an instance of the `IChannel` resource is not meant to be reused across multiple `DpaHandler2` instances, though I could well be wrong about this latter part.

**Testing performed**

Only a small amount, ran a program with the change and saw the resources being cleaned up. No unit testing.